### PR TITLE
Fixes to allow model to estimate

### DIFF
--- a/R/fable_ata.R
+++ b/R/fable_ata.R
@@ -26,8 +26,8 @@ train_ata <- function(.data, specials, ...){
       stop("ATA method does not support missing values.")
     }
     period <- fabletools::get_frequencies(season$period, .data, .auto = "smallest")
-    pre_data <- quietly(tsbox::ts_ts(.data))
-    model_data <- stats::ts(model_data$y, frequency = unname(period), start=tsp(pre_data)[1])
+    pre_data <- quietly(tsbox::ts_ts)(.data)
+    model_data <- stats::ts(model_data$y, frequency = unname(period), start=start(pre_data))
   if (holdout$holdout == TRUE & accuracy$criteria == "AMSE") {
     stop("ATA Method does not support 'AMSE' for 'holdout' forecasting.")
   }

--- a/R/fable_ata.R
+++ b/R/fable_ata.R
@@ -9,12 +9,16 @@ train_ata <- function(.data, specials, ...){
   if(length(tsibble::measured_vars(.data)) > 1){
     stop("Only univariate responses are supported by ATA Method")
   }
-  level <- specials$level
-  trend <- specials$trend
-  season <- specials$season
-  accuracy <- specials$accuracy
-  transform <- specials$transform
-  holdout <- specials$holdout
+  
+  # Allow only one special of each type.
+  # TODO: Add message/warning if more than one of these specials is in formula
+  level <- specials$level[[1]]
+  trend <- specials$trend[[1]]
+  season <- specials$season[[1]]
+  accuracy <- specials$accuracy[[1]]
+  transform <- specials$transform[[1]]
+  holdout <- specials$holdout[[1]]
+  
   # Prepare data for modelling
     model_data <- tsibble::as_tibble(.data)[c(rlang::expr_text(index(.data)), tsibble::measured_vars(.data))]
     colnames(model_data) <- c("ds", "y")
@@ -152,7 +156,8 @@ specials_ata <- fabletools::new_specials(
                     },
    holdout = function(holdout = FALSE, adjustment = TRUE, set_size = NULL ){
                         list("holdout" = holdout, "adjustment" = adjustment, "set_size" = set_size)
-                    }
+                    },
+   .required_specials = c("level", "trend", "season", "accuracy", "transform", "holdout")
 )
 
 #' ATAforecasting: Automatic Time Series Analysis and Forecasting using Ata Method with Box-Cox Power Transformations Family and Seasonal Decomposition Techniques


### PR DESCRIPTION
I figured it'd be easier to look through the code interactively and make a PR.

When debugging errors in fable models you might like to use `model(.safely=FALSE)` as this will allow errors in your code to display with tracebacks and debugging tools.

There are two problems that I had found:
1. The original problem you emailed me about was due to a misuse of `purrr::quietly()`, which modifies a function rather than wrapping a call. So instead of `quietly(f(x))` you want `quietly(f)(x)`.
2. After fixing this, the code still wouldn't run due to issues with the specials. In fable, it is possible to specify 0, 1 or more of each special. For example, `ARIMA(y)`, `ARIMA(y~trend()`, or `ARIMA(y ~ trend() + trend(knots = c(3,6))`. You can require that a special is used even if it isn't in the formula with `new_specials(.required_specials = "trend")`, which makes `ATAM(y)` equivalent to `ATAM(y ~ trend()`). I've done this to all of your specials as I think this is what you intended. Additionally, I think your model expects only one of each special, so I've indexed `specials$trend[[1]]` to keep only the first usage of `trend()`. So `ATAM(y~trend("A") + trend("N"))` is equivalent to `ATAM(y~trend("A"))`. You should probably give a warning if `length(specials$trend)>1`.

Hope this helps, let me know if you have any other issues.
Looking forward to seeing how this package progresses! :tada: :smile: